### PR TITLE
fix namehash for PBOs with badly sorted filenames

### DIFF
--- a/a3lib.py
+++ b/a3lib.py
@@ -618,7 +618,7 @@ class PboFile:
     def _namehash(self):
         """Create hash from member names."""
         namehash = hashlib.sha1()
-        for info in self.infolist():
+        for info in sorted(self.infolist(), key=lambda v: v.filename.lower()):
             if info.check_name_hash():
                 namehash.update(info.filename.lower())
         return namehash


### PR DESCRIPTION
make sure that for the namehash the filenames are always hashed in case
INsensitive order